### PR TITLE
add ga4 id to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,7 +178,7 @@ site-css:
 #################################
 
 # Fill in your Google Analytics tag ID (or "Measurement ID") to track your website usage
-#gtag: "G-XXXXXXXXXX"
+gtag: "G-CC6XR5MSNN"
 
 # Fill in your Cloudflare Analytics beacon token to track your website using Cloudflare Analytics
 #cloudflare_analytics: ""


### PR DESCRIPTION
This pull request updates the Google Analytics configuration for the site. The `gtag` value in `_config.yml` has been set to a specific Measurement ID, enabling Google Analytics tracking for the website.